### PR TITLE
OAS 2.1 cleanup

### DIFF
--- a/bundle.sh
+++ b/bundle.sh
@@ -7,6 +7,11 @@ if [ -z "$GENERATE_EXAMPLES" ]; then
 else
   echo "Generating examples"
   (cd ./requests && ./generate-examples.sh)
+  # Fail if previous command failed
+  if [ $? -ne 0 ]; then
+    echo "Failed to generate examples"
+    exit 1
+  fi
 fi
 
 redocly bundle openapi.yaml -o openapi-bundled.yaml

--- a/bundle.sh
+++ b/bundle.sh
@@ -7,11 +7,6 @@ if [ -z "$GENERATE_EXAMPLES" ]; then
 else
   echo "Generating examples"
   (cd ./requests && ./generate-examples.sh)
-  # Fail if previous command failed
-  if [ $? -ne 0 ]; then
-    echo "Failed to generate examples"
-    exit 1
-  fi
 fi
 
 redocly bundle openapi.yaml -o openapi-bundled.yaml

--- a/components/schemas/requestErrors/400/Error400RequestBodyEmpty.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestBodyEmpty.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Cannot process the request because of the empty body. Please check
-        Foxentry.dev for more information.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Cannot process the request because of the empty body. Please check

--- a/components/schemas/requestErrors/400/Error400RequestBodyNoRequest.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestBodyNoRequest.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - Your API call body does not contain any requests.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Your API call body does not contain any requests.

--- a/components/schemas/requestErrors/400/Error400RequestBodyNotJson.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestBodyNotJson.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Cannot process the request because the JSON is not valid. Please check
-        Foxentry.dev for more information.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Cannot process the request because the JSON is not valid. Please check

--- a/components/schemas/requestErrors/400/Error400RequestBodyTooBig.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestBodyTooBig.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Your request length is bigger than allowed. Please contact us if you
-        think this is a mistake.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Your request length is bigger than allowed. Please contact us if you think

--- a/components/schemas/requestErrors/400/Error400RequestClientParameterNotSupported.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestClientParameterNotSupported.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - Options parameter is not supported for this endpoint.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Options parameter is not supported for this endpoint.

--- a/components/schemas/requestErrors/400/Error400RequestClientParameterValueNotSupported.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestClientParameterValueNotSupported.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - Options parameter is not supported for this endpoint.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Options parameter is not supported for this endpoint.

--- a/components/schemas/requestErrors/400/Error400RequestOptionsParameterCombination.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestOptionsParameterCombination.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - Combination of options or their values is not valid.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Combination of options or their values is not valid.

--- a/components/schemas/requestErrors/400/Error400RequestOptionsParameterNotSupported.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestOptionsParameterNotSupported.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - Options parameter is not supported for this endpoint.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Options parameter is not supported for this endpoint.

--- a/components/schemas/requestErrors/400/Error400RequestOptionsParameterValueNotSupported.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestOptionsParameterValueNotSupported.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Value in paramater is not valid. Please check Foxentry.dev for more
-        information.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Value in paramater is not valid. Please check Foxentry.dev for more

--- a/components/schemas/requestErrors/400/Error400RequestQueryNotSent.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestQueryNotSent.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Your request query is empty. Please check Foxentry.dev for more
-        information about how to set up the query properly.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Your request query is empty. Please check Foxentry.dev for more

--- a/components/schemas/requestErrors/400/Error400RequestQueryParameterCombination.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestQueryParameterCombination.yaml
@@ -35,10 +35,9 @@ properties:
       - streetWithNumber
       - street
   description:
-    enum:
-      - >-
-        It is not possible to use these parameters at the same time in one
-        request.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       It is not possible to use these parameters at the same time in one

--- a/components/schemas/requestErrors/400/Error400RequestQueryParameterMissing.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestQueryParameterMissing.yaml
@@ -32,10 +32,9 @@ properties:
       description: Error related to.
       example: prefix
   description:
-    enum:
-      - >-
-        Query parameter is missing. Please check Foxentry.dev for more
-        information about how to set up the query properly.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Query parameter is missing. Please check Foxentry.dev for more information

--- a/components/schemas/requestErrors/400/Error400RequestQueryParameterNotSupported.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestQueryParameterNotSupported.yaml
@@ -33,7 +33,8 @@ properties:
     example:
       - unsupportedParameter
   description:
-    enum:
-      - Query parameter is not supported for this endpoint.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Query parameter is not supported for this endpoint.

--- a/components/schemas/requestErrors/400/Error400RequestQueryParameterNotSupportedForQuery.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestQueryParameterNotSupportedForQuery.yaml
@@ -34,7 +34,8 @@ properties:
     example:
       - allowPartialResults
   description:
-    enum:
-      - Parameter can not be used in combination with this query parameters.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Parameter can not be used in combination with this query parameters.

--- a/components/schemas/requestErrors/400/Error400RequestQueryParameterRequired.yaml
+++ b/components/schemas/requestErrors/400/Error400RequestQueryParameterRequired.yaml
@@ -32,7 +32,8 @@ properties:
       description: Error related to.
       example: email
   description:
-    enum:
-      - At least one of listed parameters is required.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: At least one of listed parameters is required.

--- a/components/schemas/requestErrors/401/Error401RequestAuth.yaml
+++ b/components/schemas/requestErrors/401/Error401RequestAuth.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Invalid authorization credentials sent. Check Foxentry.dev for more
-        information how to set up the AUTH properly.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Invalid authorization credentials sent. Check Foxentry.dev for more

--- a/components/schemas/requestErrors/402/Error402RequestBillingNoCredit.yaml
+++ b/components/schemas/requestErrors/402/Error402RequestBillingNoCredit.yaml
@@ -31,11 +31,10 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        No credit available. You need to purchase a sufficient ammount of
-        credits in the project administration at app.foxentry.com.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
-      No credit available. You need to purchase a sufficient ammount of credits
+      No credit available. You need to purchase a sufficient amount of credits
       in the project administration at app.foxentry.com.

--- a/components/schemas/requestErrors/403/Error403RequestAuthKey.yaml
+++ b/components/schemas/requestErrors/403/Error403RequestAuthKey.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Provided API key is not valid. Please check the project settings at
-        app.foxentry.com.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Provided API key is not valid. Please check the project settings at

--- a/components/schemas/requestErrors/403/Error403RequestAuthToken.yaml
+++ b/components/schemas/requestErrors/403/Error403RequestAuthToken.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Provided access token is not valid. Please check the project settings at
-        app.foxentry.com.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Provided access token is not valid. Please check the project settings at

--- a/components/schemas/requestErrors/403/Error403RequestNotAllowedDomain.yaml
+++ b/components/schemas/requestErrors/403/Error403RequestNotAllowedDomain.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - Website domain is not allowed in the project settings.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Website domain is not allowed in the project settings.

--- a/components/schemas/requestErrors/403/Error403RequestNotAllowedIp.yaml
+++ b/components/schemas/requestErrors/403/Error403RequestNotAllowedIp.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        The API key has IP limits set and your IP address is not allowed. Change
-        the project settings at app.foxentry.com.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       The API key has IP limits set and your IP address is not allowed. Change

--- a/components/schemas/requestErrors/404/Error404RequestApiVersion.yaml
+++ b/components/schemas/requestErrors/404/Error404RequestApiVersion.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Requested API version is not available. Please check Foxentry.dev for
-        the supported versions.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Requested API version is not available. Please check Foxentry.dev for the

--- a/components/schemas/requestErrors/404/Error404RequestEndpointNotFound.yaml
+++ b/components/schemas/requestErrors/404/Error404RequestEndpointNotFound.yaml
@@ -31,9 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Endpoint not found. Please check Foxentry.dev for the supported
-        endpoints.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Endpoint not found. Please check Foxentry.dev for the supported endpoints.

--- a/components/schemas/requestErrors/404/Error404RequestProjectNotFound.yaml
+++ b/components/schemas/requestErrors/404/Error404RequestProjectNotFound.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        The project does not exist. Please check the available projects at
-        app.foxentry.com or contact the support.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       The project does not exist. Please check the available projects at

--- a/components/schemas/requestErrors/405/Error405RequestNotAllowedMethod.yaml
+++ b/components/schemas/requestErrors/405/Error405RequestNotAllowedMethod.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        HTTP method is not allowed for this endpoint. Please check Foxentry.dev
-        for more information.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       HTTP method is not allowed for this endpoint. Please check Foxentry.dev

--- a/components/schemas/requestErrors/429/Error429RequestBillingServiceLimit.yaml
+++ b/components/schemas/requestErrors/429/Error429RequestBillingServiceLimit.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        The maximum service limit has been reached. Move to the higher paying plan or allow requests 
-        over the subscription.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       The maximum service limit has been reached. Move to the higher paying plan or allow requests 

--- a/components/schemas/requestErrors/429/Error429RequestRateLimitCreditPerDay.yaml
+++ b/components/schemas/requestErrors/429/Error429RequestRateLimitCreditPerDay.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        The maximum daily limit has been reached. Adjust the settings in the
-        project or wait until the limit is reset.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       The maximum daily limit has been reached. Adjust the settings in the

--- a/components/schemas/requestErrors/429/Error429RequestRateLimitCreditPerIp.yaml
+++ b/components/schemas/requestErrors/429/Error429RequestRateLimitCreditPerIp.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        The maximum daily limit per IP address has been reached. Adjust the
-        settings in the project or wait until the limit is reset.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       The maximum daily limit per IP address has been reached. Adjust the

--- a/components/schemas/requestErrors/429/Error429RequestRateLimitTooManyRequests.yaml
+++ b/components/schemas/requestErrors/429/Error429RequestRateLimitTooManyRequests.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        The maximum allowed request rate limit has been reached. Check
-        Foxentry.dev for more information or contact the support.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       The maximum allowed request rate limit has been reached. Check

--- a/components/schemas/requestErrors/500/Error500InternalBilling.yaml
+++ b/components/schemas/requestErrors/500/Error500InternalBilling.yaml
@@ -30,10 +30,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Failed to process your request due to a billing internal error. Please
-        contact us if the error persists.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Failed to process your request due to a billing internal error. Please

--- a/components/schemas/requestErrors/500/Error500InternalDatabaseConnection.yaml
+++ b/components/schemas/requestErrors/500/Error500InternalDatabaseConnection.yaml
@@ -30,10 +30,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Failed to establish connection with the database server. Please contact
-        us if the error persists.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Failed to establish connection with the database server. Please contact us

--- a/components/schemas/requestErrors/500/Error500InternalDatabaseError.yaml
+++ b/components/schemas/requestErrors/500/Error500InternalDatabaseError.yaml
@@ -30,11 +30,10 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        An error has occured during the communication with our database. Please
-        contact us if the error persists.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
-      An error has occured during the communication with our database. Please
+      An error has occurred during the communication with our database. Please
       contact us if the error persists.

--- a/components/schemas/requestErrors/500/Error500InternalDatabaseNotAvailable.yaml
+++ b/components/schemas/requestErrors/500/Error500InternalDatabaseNotAvailable.yaml
@@ -30,10 +30,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Internal datastore is not available at the moment. No operation on this
-        datastore is possible.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Internal datastore is not available at the moment. No operation on this

--- a/components/schemas/requestErrors/500/Error500InternalError.yaml
+++ b/components/schemas/requestErrors/500/Error500InternalError.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - Failed to process your request. Please try again later or contact us.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Failed to process your request. Please try again later or contact us.

--- a/components/schemas/requestErrors/500/Error500RequestProjectNoData.yaml
+++ b/components/schemas/requestErrors/500/Error500RequestProjectNoData.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        Failed to fetch project data needed for processing your request. Please
-        contact us if the error persists.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Failed to fetch project data needed for processing your request. Please

--- a/components/schemas/requestErrors/500/Error500Timeout.yaml
+++ b/components/schemas/requestErrors/500/Error500Timeout.yaml
@@ -31,7 +31,8 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - API timeout in effect. Your request took too much time to process.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: API timeout in effect. Your request took too much time to process.

--- a/components/schemas/requestErrors/503/Error503RequestEndpointNotAvailable.yaml
+++ b/components/schemas/requestErrors/503/Error503RequestEndpointNotAvailable.yaml
@@ -31,10 +31,9 @@ properties:
       type: string
       description: Error related to.
   description:
-    enum:
-      - >-
-        API endpoint is temporary unavailable. Please contact us at
-        info@foxentry.com if the error persists.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       API endpoint is temporary unavailable. Please contact us at

--- a/components/schemas/requests/ClientRequest.yaml
+++ b/components/schemas/requests/ClientRequest.yaml
@@ -6,8 +6,14 @@ description: >-
 properties:
   ip:
     type: string
-    example: 127.0.1.1
-    format: ipv4
+    description: >-
+      IP address of your end user (IPv4 or IPv6). Used for geolocation to make
+      results — for example for the search endpoints — more relevant to the
+      user's location. If you have the user's GPS coordinates, prefer sending
+      those via `location`, as an IP address may be less precise.
+    examples:
+      - 127.0.1.1
+      - 2001:db8::8a2e:370:7334
   country:
     type: string
     description: >-

--- a/components/schemas/requests/company/CompanyOptions.yaml
+++ b/components/schemas/requests/company/CompanyOptions.yaml
@@ -57,7 +57,7 @@ properties:
     description: >-
       This option determines the format in which the country is returned. Supported
       formats: <b>alpha2</b> = CZ, <b>alpha3</b> = CZE, <b>local</b> = Česká republika,  <b>international</b>
-      = Czech republic, <b>localShortened</b> = Česko, <b>internationalShortened</b>
+      = Czech Republic, <b>localShortened</b> = Česko, <b>internationalShortened</b>
       = Czechia.
     type: string
     enum:

--- a/components/schemas/requests/company/CompanySearchBody.yaml
+++ b/components/schemas/requests/company/CompanySearchBody.yaml
@@ -27,7 +27,7 @@ properties:
         description: >-
           Additional filter in order to specify the search results. You can for
           example set as a filter country CZ, so the the search engine would
-          look for the companies only in the Czech republic. Pay attention to
+          look for the companies only in the Czech Republic. Pay attention to
           the options, which determines how the filter should behave.
         properties:
           name:

--- a/components/schemas/requests/location/LocationOptions.yaml
+++ b/components/schemas/requests/location/LocationOptions.yaml
@@ -66,7 +66,7 @@ properties:
   countryFormat:
     description: >-
       This option determines the format in which the country is returned. Choices
-      include local (<b>Česká republika</b>) and international (<b>Czech republic</b>)
+      include local (<b>Česká republika</b>) and international (<b>Czech Republic</b>)
       variants with their  shortened counterparts (<b>Česko, Czechia</b>). You can
       use ISO 3166 alpha codes (<b>CZ, CZE</b>) as well.
     type: string

--- a/components/schemas/requests/location/LocationValidationBody.yaml
+++ b/components/schemas/requests/location/LocationValidationBody.yaml
@@ -87,7 +87,7 @@ properties:
           - "null"
         description: >-
           Country code. Supported formats: <b>alpha2</b> = CZ, <b>alpha3</b> = CZE, <b>local</b> = Česká republika, 
-          <b>international</b> = Czech republic, <b>localShortened</b> = Česko, <b>internationalShortened</b> = Czechia.
+          <b>international</b> = Czech Republic, <b>localShortened</b> = Česko, <b>internationalShortened</b> = Czechia.
         example: CZ
   options:
     allOf:

--- a/components/schemas/results/company/CompanyData.yaml
+++ b/components/schemas/results/company/CompanyData.yaml
@@ -450,7 +450,7 @@ properties:
                       zvláštní práva a povinnosti
           stocks:
             type: array
-            description: Textual description of the stock ammount and value.
+            description: Textual description of the stock amount and value.
             items:
               type: string
               description: List of stocks.

--- a/components/schemas/results/company/CompanyValidationResult.yaml
+++ b/components/schemas/results/company/CompanyValidationResult.yaml
@@ -12,7 +12,8 @@ properties:
           which indicates a non-specific error.
         example: false
       proposal:
-        enum:
+        type: string
+        examples:
           - valid
           - validWithSuggestion
           - invalid

--- a/components/schemas/results/company/CompanyValidationResult.yaml
+++ b/components/schemas/results/company/CompanyValidationResult.yaml
@@ -17,14 +17,30 @@ properties:
           - valid
           - validWithSuggestion
           - invalid
-          - invalidWithCorrection
-          - invalidWithPartialCorrection
           - invalidWithSuggestion
+          - invalidWithCorrection
           - invalidWithCorrectionWithSuggestion
-        description: >-
+          - invalidWithPartialCorrection
+          - invalidWithPartialCorrectionWithSuggestion
+        description: |-
           Proposed solution by Foxentry how you should process the response in
           your form or application.
-        example: valid
+
+          The value is composed of three parts: the validity of `result`, the
+          validity of `resultCorrected` (appending `WithCorrection` or
+          `WithPartialCorrection`), and the presence of `suggestions`
+          (appending `WithSuggestion`). It is always a string and is never null.
+
+          Complete list of possible values:
+
+          - `valid`
+          - `validWithSuggestion`
+          - `invalid`
+          - `invalidWithSuggestion`
+          - `invalidWithCorrection`
+          - `invalidWithCorrectionWithSuggestion`
+          - `invalidWithPartialCorrection`
+          - `invalidWithPartialCorrectionWithSuggestion`
     allOf:
       - $ref: ./CompanyDataValidity.yaml
   resultCorrected:

--- a/components/schemas/results/email/EmailValidationResult.yaml
+++ b/components/schemas/results/email/EmailValidationResult.yaml
@@ -17,15 +17,45 @@ properties:
           - valid
           - validWithSuggestion
           - invalid
-          - invalidWithCorrection
-          - invalidWithPartialCorrection
           - invalidWithSuggestion
+          - invalidWithCorrection
           - invalidWithCorrectionWithSuggestion
+          - invalidWithPartialCorrection
+          - invalidWithPartialCorrectionWithSuggestion
+          - unknown
+          - unknownWithSuggestion
           - unknownWithCorrection
+          - unknownWithCorrectionWithSuggestion
           - unknownWithPartialCorrection
-        description: >-
+          - unknownWithPartialCorrectionWithSuggestion
+        description: |-
           Proposed solution by Foxentry how you should process the response in
           your form or application.
+
+          The value is composed of three parts: the validity of `result`, the
+          validity of `resultCorrected` (appending `WithCorrection` or
+          `WithPartialCorrection`), and the presence of `suggestions`
+          (appending `WithSuggestion`). It is always a string and is never null.
+
+          Complete list of possible values:
+
+          - `valid`
+          - `validWithSuggestion`
+          - `invalid`
+          - `invalidWithSuggestion`
+          - `invalidWithCorrection`
+          - `invalidWithCorrectionWithSuggestion`
+          - `invalidWithPartialCorrection`
+          - `invalidWithPartialCorrectionWithSuggestion`
+          - `unknown`
+          - `unknownWithSuggestion`
+          - `unknownWithCorrection`
+          - `unknownWithCorrectionWithSuggestion`
+          - `unknownWithPartialCorrection`
+          - `unknownWithPartialCorrectionWithSuggestion`
+
+          In practice the `unknown*` variants occur mainly as `unknown`,
+          `unknownWithCorrection` and `unknownWithSuggestion`.
     allOf:
       - $ref: ./EmailDataValidity.yaml
   resultCorrected:

--- a/components/schemas/results/email/EmailValidationResult.yaml
+++ b/components/schemas/results/email/EmailValidationResult.yaml
@@ -12,7 +12,8 @@ properties:
           which indicates a non-specific error.
         example: false
       proposal:
-        enum:
+        type: string
+        examples:
           - valid
           - validWithSuggestion
           - invalid

--- a/components/schemas/results/location/LocationValidationResult.yaml
+++ b/components/schemas/results/location/LocationValidationResult.yaml
@@ -17,15 +17,30 @@ properties:
           - valid
           - validWithSuggestion
           - invalid
-          - invalidWithCorrection
-          - invalidWithPartialCorrection
           - invalidWithSuggestion
+          - invalidWithCorrection
           - invalidWithCorrectionWithSuggestion
+          - invalidWithPartialCorrection
           - invalidWithPartialCorrectionWithSuggestion
-        description: >-
+        description: |-
           Proposed solution by Foxentry how you should process the response in
           your form or application.
-        example: invalidWithCorrection
+
+          The value is composed of three parts: the validity of `result`, the
+          validity of `resultCorrected` (appending `WithCorrection` or
+          `WithPartialCorrection`), and the presence of `suggestions`
+          (appending `WithSuggestion`). It is always a string and is never null.
+
+          Complete list of possible values:
+
+          - `valid`
+          - `validWithSuggestion`
+          - `invalid`
+          - `invalidWithSuggestion`
+          - `invalidWithCorrection`
+          - `invalidWithCorrectionWithSuggestion`
+          - `invalidWithPartialCorrection`
+          - `invalidWithPartialCorrectionWithSuggestion`
     allOf:
       - $ref: ./LocationDataValidity.yaml
     required:

--- a/components/schemas/results/location/LocationValidationResult.yaml
+++ b/components/schemas/results/location/LocationValidationResult.yaml
@@ -12,7 +12,8 @@ properties:
           which indicates a non-specific error.
         example: false
       proposal:
-        enum:
+        type: string
+        examples:
           - valid
           - validWithSuggestion
           - invalid
@@ -21,7 +22,6 @@ properties:
           - invalidWithSuggestion
           - invalidWithCorrectionWithSuggestion
           - invalidWithPartialCorrectionWithSuggestion
-          - null
         description: >-
           Proposed solution by Foxentry how you should process the response in
           your form or application.

--- a/components/schemas/results/name/NameValidationResult.yaml
+++ b/components/schemas/results/name/NameValidationResult.yaml
@@ -17,14 +17,30 @@ properties:
           - valid
           - validWithSuggestion
           - invalid
-          - invalidWithCorrection
-          - invalidWithPartialCorrection
           - invalidWithSuggestion
+          - invalidWithCorrection
           - invalidWithCorrectionWithSuggestion
-        description: >-
+          - invalidWithPartialCorrection
+          - invalidWithPartialCorrectionWithSuggestion
+        description: |-
           Proposed solution by Foxentry how you should process the response in
           your form or application.
-        example: validWithSuggestion
+
+          The value is composed of three parts: the validity of `result`, the
+          validity of `resultCorrected` (appending `WithCorrection` or
+          `WithPartialCorrection`), and the presence of `suggestions`
+          (appending `WithSuggestion`). It is always a string and is never null.
+
+          Complete list of possible values:
+
+          - `valid`
+          - `validWithSuggestion`
+          - `invalid`
+          - `invalidWithSuggestion`
+          - `invalidWithCorrection`
+          - `invalidWithCorrectionWithSuggestion`
+          - `invalidWithPartialCorrection`
+          - `invalidWithPartialCorrectionWithSuggestion`
     allOf:
       - $ref: ./NameDataValidity.yaml
 

--- a/components/schemas/results/name/NameValidationResult.yaml
+++ b/components/schemas/results/name/NameValidationResult.yaml
@@ -12,7 +12,8 @@ properties:
           which indicates a non-specific error.
         example: false
       proposal:
-        enum:
+        type: string
+        examples:
           - valid
           - validWithSuggestion
           - invalid

--- a/components/schemas/results/phone/PhoneValidationResult.yaml
+++ b/components/schemas/results/phone/PhoneValidationResult.yaml
@@ -17,14 +17,30 @@ properties:
           - valid
           - validWithSuggestion
           - invalid
-          - invalidWithCorrection
-          - invalidWithPartialCorrection
           - invalidWithSuggestion
+          - invalidWithCorrection
           - invalidWithCorrectionWithSuggestion
-        description: >-
+          - invalidWithPartialCorrection
+          - invalidWithPartialCorrectionWithSuggestion
+        description: |-
           Proposed solution by Foxentry how you should process the response in
           your form or application.
-        example: invalidWithCorrection
+
+          The value is composed of three parts: the validity of `result`, the
+          validity of `resultCorrected` (appending `WithCorrection` or
+          `WithPartialCorrection`), and the presence of `suggestions`
+          (appending `WithSuggestion`). It is always a string and is never null.
+
+          Complete list of possible values:
+
+          - `valid`
+          - `validWithSuggestion`
+          - `invalid`
+          - `invalidWithSuggestion`
+          - `invalidWithCorrection`
+          - `invalidWithCorrectionWithSuggestion`
+          - `invalidWithPartialCorrection`
+          - `invalidWithPartialCorrectionWithSuggestion`
     allOf:
       - $ref: ./PhoneDataValidity.yaml
     required:

--- a/components/schemas/results/phone/PhoneValidationResult.yaml
+++ b/components/schemas/results/phone/PhoneValidationResult.yaml
@@ -12,7 +12,8 @@ properties:
           which indicates a non-specific error.
         example: false
       proposal:
-        enum:
+        type: string
+        examples:
           - valid
           - validWithSuggestion
           - invalid
@@ -20,7 +21,6 @@ properties:
           - invalidWithPartialCorrection
           - invalidWithSuggestion
           - invalidWithCorrectionWithSuggestion
-          - null
         description: >-
           Proposed solution by Foxentry how you should process the response in
           your form or application.

--- a/components/schemas/validationErrors/ErrorFormatGlobal.yaml
+++ b/components/schemas/validationErrors/ErrorFormatGlobal.yaml
@@ -39,13 +39,9 @@ properties:
       description: Error related to.
       example: numberWithPrefix
   description:
-    enum:
-      - >-
-        Invalid case sensitivity. Specific rules are applied to the use of upper
-        and lower case letters.
-      - Invalid diacritics. Specific rules are applied to the use of diacritics.
-      - Invalid use of spaces. Specific rules are applied to the use of spaces.
-      - null
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: >-
       Invalid case sensitivity. Specific rules are applied to the use of upper

--- a/components/schemas/validationErrors/ErrorSyntaxCompany.yaml
+++ b/components/schemas/validationErrors/ErrorSyntaxCompany.yaml
@@ -35,8 +35,8 @@ properties:
       description: Error related to.
       example: name
   description:
-    enum:
-      - Value contains duplicated legal form.
-      - Company name is missing the legal form.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Value contains duplicated legal form.

--- a/components/schemas/validationErrors/ErrorSyntaxEmail.yaml
+++ b/components/schemas/validationErrors/ErrorSyntaxEmail.yaml
@@ -42,12 +42,8 @@ properties:
       description: Error related to.
       example: email
   description:
-    enum:
-      - The domain contains invalid syntax.
-      - Value contains duplicated '@' sign.
-      - Value does not contain '@' sign.
-      - Value is missing the top level domain.
-      - The TLD part of the value is placed in the wrong position.
-      - Value has invalid syntax.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: The domain contains invalid syntax.

--- a/components/schemas/validationErrors/ErrorSyntaxGlobal.yaml
+++ b/components/schemas/validationErrors/ErrorSyntaxGlobal.yaml
@@ -43,13 +43,8 @@ properties:
       description: Error related to.
       example: numberWithPrefix
   description:
-    enum:
-      - Disallowed characters were used in the value.
-      - Value contains invalid use of spaces.
-      - Value has invalid syntax.
-      - Cannot be processed due to the invalid syntax.
-      - Value is too long.
-      - Value is too short.
-      - Value contains unneccessary context.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Disallowed characters were used in the value.

--- a/components/schemas/validationErrors/ErrorSyntaxLocation.yaml
+++ b/components/schemas/validationErrors/ErrorSyntaxLocation.yaml
@@ -38,12 +38,8 @@ properties:
       description: Error related to.
       example: streetWithNumber
   description:
-    enum:
-      - Value is missing the city.
-      - Value is missing the number.
-      - Value is missing the number part.
-      - Value is missing the street.
-      - Value is missing the zip.
-      - Value is missing some part of the number.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Value is missing the city.

--- a/components/schemas/validationErrors/ErrorSyntaxName.yaml
+++ b/components/schemas/validationErrors/ErrorSyntaxName.yaml
@@ -37,9 +37,8 @@ properties:
       description: Error related to.
       example: name
   description:
-    enum:
-      - Value is missing the name part.
-      - Value is missing the surname part.
-      - The DEGREE part of the value is placed in the wrong position.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Value is missing the name part.

--- a/components/schemas/validationErrors/ErrorSyntaxPhone.yaml
+++ b/components/schemas/validationErrors/ErrorSyntaxPhone.yaml
@@ -37,10 +37,8 @@ properties:
       description: Error related to.
       example: numberWithPrefix
   description:
-    enum:
-      - Value contains duplicated '+' sign.
-      - Value is missing the number.
-      - Value is missing the '+' sign.
-      - Value is missing the prefix.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Value contains duplicated '+' sign.

--- a/components/schemas/validationErrors/ErrorTemporaryInvalidEmail.yaml
+++ b/components/schemas/validationErrors/ErrorTemporaryInvalidEmail.yaml
@@ -35,7 +35,8 @@ properties:
       description: Error related to.
       example: email
   description:
-    enum:
-      - Mailbox is full and cannot receive any e-mails at the moment.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Mailbox is full and cannot receive any e-mails at the moment.

--- a/components/schemas/validationErrors/ErrorValueEmail.yaml
+++ b/components/schemas/validationErrors/ErrorValueEmail.yaml
@@ -39,10 +39,8 @@ properties:
       description: Error related to.
       example: email
   description:
-    enum:
-      - Domain name is invalid.
-      - Domain does not have DNS records set properly for receiving emails.
-      - Disposable emails are not allowed.
-      - Freemails are not allowed.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Domain name is invalid.

--- a/components/schemas/validationErrors/ErrorValueGlobal.yaml
+++ b/components/schemas/validationErrors/ErrorValueGlobal.yaml
@@ -40,11 +40,5 @@ properties:
     type:
       - string
       - "null"
-    enum:
-      - Value is empty.
-      - Value contains parts in incorrect order.
-      - Value is not valid.
-      - The Combination of values listed in relatedTo section is not valid.
-      - Context words are not allowed.
     description: Description of error.
     example: Value is empty.

--- a/components/schemas/validationErrors/ErrorValueGlobal.yaml
+++ b/components/schemas/validationErrors/ErrorValueGlobal.yaml
@@ -37,7 +37,9 @@ properties:
       description: Error related to.
       example: numberWithPrefix
   description:
-    type: string
+    type:
+      - string
+      - "null"
     enum:
       - Value is empty.
       - Value contains parts in incorrect order.

--- a/components/schemas/validationErrors/ErrorValueName.yaml
+++ b/components/schemas/validationErrors/ErrorValueName.yaml
@@ -39,11 +39,8 @@ properties:
       description: Error related to.
       example: name
   description:
-    enum:
-      - Degree value is invalid.
-      - Name has not been found in our database.
-      - NameSurname has not been found in our database.
-      - Surname has not been found in our database.
-      - Degrees are not allowed.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Degree value is invalid.

--- a/components/schemas/validationErrors/ErrorValuePhone.yaml
+++ b/components/schemas/validationErrors/ErrorValuePhone.yaml
@@ -35,10 +35,8 @@ properties:
       description: Error related to.
       example: numberWithPrefix
   description:
-    enum:
-      - Prefix is invalid.
-      - >-
-        This prefix is not allowed. Check the 'allowedPrefixes' option in the
-        request.
+    type:
+      - string
+      - "null"
     description: Description of error.
     example: Prefix is invalid.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -113,8 +113,8 @@ info:
 
     As part of our commitment to data security, you are required to obtain a
     <b>Bearer token</b> from Foxentry. If you are a new user and do not have an
-    API key, please fill out our registration form at
-    https://app.foxentry.com/registration. 
+    API key, create your account at https://app.foxentry.com/registration and
+    generate the key in your project settings. 
 
 
     ## Need help? 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -64,48 +64,48 @@ info:
       </tr>
       <tr>
         <td>company/validate</td>
-        <td>Czech Republic, Slovakia, and Poland</td>
+        <td>Czech Republic, Hungary, Poland, and Slovakia</td>
       </tr>
       <tr>
         <td>company/search</td>
-        <td>Czech Republic, Slovakia, and Poland</td>
+        <td>Czech Republic, Hungary, Poland, and Slovakia</td>
       </tr>
       <tr>
         <td>company/get</td>
-        <td>Czech Republic, Slovakia, and Poland</td>
-      </tr> 
+        <td>Czech Republic, Hungary, Poland, and Slovakia</td>
+      </tr>
       <tr>
         <td>email/validate</td>
         <td>Worldwide</td>
-      </tr> 
+      </tr>
       <tr>
         <td>email/search</td>
         <td>Worldwide</td>
-      </tr> 
+      </tr>
       <tr>
         <td>location/validate</td>
-        <td>Czech Republic, Slovakia, and Poland</td>
-      </tr> 
+        <td>Albania, Andorra, Austria, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, France, Germany, Greece, Hungary, Iceland, Italy, Kosovo, Liechtenstein, Luxembourg, Malta, Monaco, Montenegro, Netherlands, North Macedonia, Poland, Romania, San Marino, Serbia, Slovakia, Slovenia, Spain, Switzerland, United Kingdom, and Vatican City</td>
+      </tr>
       <tr>
         <td>location/search</td>
-        <td>Czech Republic, Slovakia, and Poland</td>
-      </tr> 
+        <td>Albania, Andorra, Austria, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, France, Germany, Greece, Hungary, Iceland, Italy, Kosovo, Liechtenstein, Luxembourg, Malta, Monaco, Montenegro, Netherlands, North Macedonia, Poland, Romania, San Marino, Serbia, Slovakia, Slovenia, Spain, Switzerland, United Kingdom, and Vatican City</td>
+      </tr>
       <tr>
         <td>location/get</td>
-        <td>Czech Republic, Slovakia, and Poland</td>
-      </tr> 
+        <td>Albania, Andorra, Austria, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, France, Germany, Greece, Hungary, Iceland, Italy, Kosovo, Liechtenstein, Luxembourg, Malta, Monaco, Montenegro, Netherlands, North Macedonia, Poland, Romania, San Marino, Serbia, Slovakia, Slovenia, Spain, Switzerland, United Kingdom, and Vatican City</td>
+      </tr>
       <tr>
         <td>location/localize</td>
-        <td>Czech Republic, Slovakia, and Poland</td>
-      </tr> 
+        <td>Albania, Andorra, Austria, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, France, Germany, Greece, Hungary, Iceland, Italy, Kosovo, Liechtenstein, Luxembourg, Malta, Monaco, Montenegro, Netherlands, North Macedonia, Poland, Romania, San Marino, Serbia, Slovakia, Slovenia, Spain, Switzerland, United Kingdom, and Vatican City</td>
+      </tr>
       <tr>
         <td>name/validate</td>
-        <td>Czech Republic, Slovakia</td>
-      </tr> 
+        <td>Czech Republic and Slovakia</td>
+      </tr>
       <tr>
         <td>phone/validate</td>
         <td>Worldwide</td>
-      </tr>                                                                
+      </tr>
     </table>
 
 
@@ -114,7 +114,7 @@ info:
     As part of our commitment to data security, you are required to obtain a
     <b>Bearer token</b> from Foxentry. If you are a new user and do not have an
     API key, please fill out our registration form at
-    https://foxentry.com/help-center/rest-api. 
+    https://app.foxentry.com/registration. 
 
 
     ## Need help? 
@@ -129,7 +129,6 @@ info:
     url: https://www.foxentry.com
 servers:
   - url: https://api.foxentry.com
-  - url: https://api.foxentry.com/v2.1
 paths:
   /company/validate:
     $ref: paths/company/CompanyValidate.yaml

--- a/paths/company/CompanyGet.yaml
+++ b/paths/company/CompanyGet.yaml
@@ -35,6 +35,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/company/CompanySearch.yaml
+++ b/paths/company/CompanySearch.yaml
@@ -38,6 +38,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/company/CompanyValidate.yaml
+++ b/paths/company/CompanyValidate.yaml
@@ -6,7 +6,7 @@ post:
     This endpoint requires at least 1 query parameter and will check if the
     parameters and their combinations are valid. Returns information about the
     company based on the datascope set in the options.<br><br> Foxentry
-    validator is able not only to evaluate the validity of the inputed
+    validator is able not only to evaluate the validity of the entered
     information but it also can fix various typos, errors and missing data.
     Foxentry can also suggest more suitable alternatives to the data sent in
     query. Please pay attention to the <b>result</b>, <b>resultCorrected</b> and
@@ -42,6 +42,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/email/EmailSearch.yaml
+++ b/paths/email/EmailSearch.yaml
@@ -37,6 +37,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/email/EmailValidate.yaml
+++ b/paths/email/EmailValidate.yaml
@@ -9,7 +9,7 @@ post:
     (default) is the more advanced type that checks the real existence of the
     e-mail address and its deliverability. It also informs you about various
     flags such as <b>freemail and disposable mail</b> detection. <br><br>
-    Foxentry validator is able not only to evaluate the validity of the inputed
+    Foxentry validator is able not only to evaluate the validity of the entered
     information but it also can fix various typos, errors and missing data.
     Foxentry can also suggest more suitable alternatives to the data sent in
     query. Please pay attention to the <b>result</b>, <b>resultCorrected</b> and
@@ -45,6 +45,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/location/LocationGet.yaml
+++ b/paths/location/LocationGet.yaml
@@ -37,6 +37,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/location/LocationLocalize.yaml
+++ b/paths/location/LocationLocalize.yaml
@@ -37,6 +37,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/location/LocationSearch.yaml
+++ b/paths/location/LocationSearch.yaml
@@ -38,6 +38,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/location/LocationValidate.yaml
+++ b/paths/location/LocationValidate.yaml
@@ -6,7 +6,7 @@ post:
     This endpoint requires at least 1 query parameter and will check if the
     parameters and their combinations are valid. Returns information about the
     location based on the datascope set in the options.<br><br> Foxentry
-    validator is able not only to evaluate the validity of the inputed
+    validator is able not only to evaluate the validity of the entered
     information but it also can fix various typos, errors and missing data.
     Foxentry can also suggest more suitable alternatives to the data sent in
     query. Please pay attention to the <b>result</b>, <b>resultCorrected</b> and
@@ -42,6 +42,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/name/NameValidate.yaml
+++ b/paths/name/NameValidate.yaml
@@ -11,7 +11,7 @@ post:
     based on your use case. For example you''d want minimal validationDepth for
     web forms since you usually don''t want to disturb the user too much with
     error messages and suggestions.   <br><br> Foxentry validator is able not
-    only to evaluate the validity of the inputed information but it also can fix
+    only to evaluate the validity of the entered information but it also can fix
     various typos, errors and missing data. Foxentry can also suggest more
     suitable alternatives to the data sent in query. Please pay attention to the
     <b>result</b>, <b>resultCorrected</b> and <b>suggestions</b> in the
@@ -47,6 +47,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/phone/PhoneSearch.yaml
+++ b/paths/phone/PhoneSearch.yaml
@@ -35,6 +35,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1

--- a/paths/phone/PhoneValidate.yaml
+++ b/paths/phone/PhoneValidate.yaml
@@ -8,7 +8,7 @@ post:
     based on the <b>validationType</b> option.<br><br>Please pay attention to
     the <b>formatNumber</b> option. This option defines the format of number
     that should be considered as valid. <br><br>Foxentry validator is able not
-    only to evaluate the validity of the inputed information but it also can fix
+    only to evaluate the validity of the entered information but it also can fix
     various typos, errors and missing data. Foxentry can also suggest more
     suitable alternatives to the data sent in query. Please pay attention to the
     <b>result</b>, <b>resultCorrected</b> and <b>suggestions</b> in the
@@ -44,6 +44,3 @@ post:
       $ref: ./../../components/responses/error/Error503Response.yaml
   security:
     - BearerAuth: []
-  servers:
-    - url: https://api.foxentry.com
-    - url: https://api.foxentry.com/v2.1


### PR DESCRIPTION
# API 2.1 cleanup

Consistency and accuracy pass over the 2.1 spec. Bundles and lints clean (`redocly lint` → 0 warnings).

## Schema

- **`proposal`** (all `*ValidationResult` schemas): documented as a `string` with the **complete list of possible values**, plus an explanation of how the value is composed (validity of `result` × validity of `resultCorrected` × presence of `suggestions`). `email/validate` additionally documents the `unknown*` variants. It is never null.
- **Error `description`**: modelled as a nullable string (`type: [string, "null"]`) rather than an enum, since the message text can change and may be null for some errors.
- **`client.ip`**: now documented as an IPv4 **or** IPv6 address (used for geolocation), with examples for both.

## Servers & versioning

- Removed the `/v2.1` path server and the duplicated per-operation `servers` blocks. The API version is selected through the `Api-Version` header.

## Content

- Regenerated the **Supported countries** table in the API description from the `dataSource` definitions.
- Reworded the registration note and unified the link to `app.foxentry.com/registration`.
- Fixed typos in a few descriptions.

## Verification

```
redocly bundle openapi.yaml
redocly lint openapi.yaml    # valid, 0 warnings
```
